### PR TITLE
`hyperdrive-archive-swarm` package missing from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gh-pages-deploy": "^0.4.2",
     "http-server": "^0.9.0",
     "hyperdrive": "^6.2.1",
+    "hyperdrive-archive-swarm": "^1.1.0",
     "level-browserify": "^1.1.0",
     "memdb": "^1.3.1",
     "standard": "^3.0.0",


### PR DESCRIPTION
Seems not on purpose so i am adding it back in.
