### PR TITLE
Alternative api

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,6 @@ var speedometer = require('speedometer')
 var prettyBytes = require('pretty-bytes')
 var path = require('path')
 var intro = require('intro.js')
-var yo = require('yo-yo')
 var explorer = require('./')
 
 var $hyperdrive = document.querySelector('#hyperdrive-ui')

--- a/app.js
+++ b/app.js
@@ -10,9 +10,9 @@ var drive = hyperdrive(db)
 var speedometer = require('speedometer')
 var prettyBytes = require('pretty-bytes')
 var path = require('path')
-var explorer = require('./')
 var intro = require('intro.js')
 var yo = require('yo-yo')
+var explorer = require('./')
 
 var $hyperdrive = document.querySelector('#hyperdrive-ui')
 var $shareLink = document.getElementById('share-link')
@@ -87,29 +87,13 @@ function main (key) {
     window.location = '#' + archive.key.toString('hex')
     updateShareLink()
 
-    var entries = []
-    var widget
-
-    function update () {
-      var fresh = explorer(archive, entries, function (ev, entry) {
-        if (entry.type === 'directory') {
-          cwd = entry.name
-        }
-      })
-      if (widget) widget = yo.update(widget, fresh)
-      else widget = fresh
+    function onclick (ev, entry) {
+      if (entry.type === 'directory') {
+        cwd = entry.name
+      }
     }
-
-    update()
-    $hyperdrive.appendChild(widget)
-
-    var stream = archive.list({live: true})
-    stream.on('data', function (entry) {
-      if (archive.owner) help.innerHTML = 'drag and drop files'
-      else help.innerHTML = ''
-      entries.push(entry)
-      update()
-    })
+    var tree = explorer(archive, onclick)
+    $hyperdrive.appendChild(tree)
   })
 }
 

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ var prettyBytes = require('pretty-bytes')
 var path = require('path')
 var explorer = require('./')
 var intro = require('intro.js')
+var yo = require('yo-yo')
 
 var $hyperdrive = document.querySelector('#hyperdrive-ui')
 var $shareLink = document.getElementById('share-link')
@@ -86,16 +87,28 @@ function main (key) {
     window.location = '#' + archive.key.toString('hex')
     updateShareLink()
 
-    var widget = explorer(archive, function (ev, entry) {
-      if (entry.type === 'directory') {
-        cwd = entry.name
-      }
-    })
+    var entries = []
+    var widget
+
+    function update () {
+      var fresh = explorer(archive, entries, function (ev, entry) {
+        if (entry.type === 'directory') {
+          cwd = entry.name
+        }
+      })
+      if (widget) widget = yo.update(widget, fresh)
+      else widget = fresh
+    }
+
+    update()
     $hyperdrive.appendChild(widget)
+
     var stream = archive.list({live: true})
     stream.on('data', function (entry) {
       if (archive.owner) help.innerHTML = 'drag and drop files'
       else help.innerHTML = ''
+      entries.push(entry)
+      update()
     })
   })
 }

--- a/index.js
+++ b/index.js
@@ -3,13 +3,24 @@ var yo = require('yo-yo')
 var data = require('render-data')
 var yofs = require('yo-fs')
 
-module.exports = function ui (archive, opts, onclick) {
-  if (!onclick) return ui(archive, opts, function thunk () {})
-  if ((typeof opts) === 'function') return ui(archive, {}, opts)
+module.exports = function ui (archive, entries, opts, onclick) {
+  if (!onclick) return ui(archive, entries, opts, function thunk () {})
+  if ((typeof opts) === 'function') return ui(archive, entries, {}, opts)
   if (!opts) opts = {}
   var root = opts.root || '/'
-  var entries = []
   var dirs = {}
+
+  entries.forEach(function (entry) {
+    var dir = path.dirname(entry.name)
+    if (!dirs[dir]) {
+      entries.push({
+        type: 'directory',
+        name: dir,
+        length: 0
+      })
+      dirs[dir] = true
+    }
+  })
 
   var fs = yofs(null, root, entries, clickEntry)
   var displayId = 'display'
@@ -53,19 +64,5 @@ module.exports = function ui (archive, opts, onclick) {
     onclick(ev, entry)
   }
 
-  var stream = archive.list({live: true})
-  stream.on('data', function (entry) {
-    entries.push(entry)
-    var dir = path.dirname(entry.name)
-    if (!dirs[dir]) {
-      entries.push({
-        type: 'directory',
-        name: dir,
-        length: 0
-      })
-      dirs[dir] = true
-    }
-    yofs(fs, root, entries, clickEntry)
-  })
   return widget
 }

--- a/index.js
+++ b/index.js
@@ -10,10 +10,17 @@ module.exports = function ui (archive, opts, onclick) {
   var dirs = {}
   var entries = []
 
-  var tree = yofs('/', entries, onclick)
+  function clicky (ev, entry) {
+    if (entry.type === 'directory') {
+      root = entry.name
+    }
+    onclick(ev, entry)
+  }
+
+  var tree = yofs(root, entries, clicky)
 
   function update () {
-    var fresh = tree.render('/', entries, onclick)
+    var fresh = tree.render(root, entries, clicky)
     yo.update(tree.widget, fresh)
   }
 

--- a/index.js
+++ b/index.js
@@ -1,16 +1,30 @@
 var path = require('path')
 var yo = require('yo-yo')
-var data = require('render-data')
 var yofs = require('yo-fs')
 
-module.exports = function ui (archive, entries, opts, onclick) {
-  if (!onclick) return ui(archive, entries, opts, function thunk () {})
-  if ((typeof opts) === 'function') return ui(archive, entries, {}, opts)
+module.exports = function ui (archive, opts, onclick) {
+  if (!onclick) return ui(archive, opts, function thunk () {})
+  if ((typeof opts) === 'function') return ui(archive, {}, opts)
   if (!opts) opts = {}
   var root = opts.root || '/'
   var dirs = {}
+  var entries = []
 
-  entries.forEach(function (entry) {
+  var tree = yofs('/', entries, onclick)
+
+  function update () {
+    var fresh = tree.render('/', entries, onclick)
+    yo.update(tree.widget, fresh)
+  }
+
+  var stream = archive.list({live: true})
+  stream.on('data', function (entry) {
+    if (archive.owner) help.innerHTML = 'drag and drop files'
+    else help.innerHTML = ''
+    entry.createReadStream = function () {
+      return archive.createFileReadStream(entry)
+    }
+    entries.push(entry)
     var dir = path.dirname(entry.name)
     if (!dirs[dir]) {
       entries.push({
@@ -20,49 +34,7 @@ module.exports = function ui (archive, entries, opts, onclick) {
       })
       dirs[dir] = true
     }
+    update()
   })
-
-  var fs = yofs(null, root, entries, clickEntry)
-  var displayId = 'display'
-  var display = yo`<div id="${displayId}"></div>`
-
-  var widget = yo`<div id="hyperdrive-ui">
-    ${fs}
-    ${display}
-  </div>`
-
-/*
-  function page (newRoot) {
-    root = newRoot
-    yofs(fs, newRoot, entries, clickEntry)
-  }
-
-  function breadcrumbs (root) {
-    var parts = root.split('/')
-    while (parts[parts.length - 1] === '') { parts.pop() }
-    function back () { page(path.dirname(root)) }
-    var crumbs
-    if (parts.length) crumbs = yo`<button class="link" onclick=${back}>back</button>`
-    return yo`<div id="breadcrumbs" class="breadcrumbs"> ${crumbs} </div>`
-  }
-*/
-  function clickEntry (ev, entry) {
-    root = entry.name
-    if (entry.type === 'directory') {
-      document.getElementById(displayId).innerHTML = ''
-    }
-    if (entry.type === 'file') {
-      data.render({
-        name: entry.name,
-        createReadStream: function () {
-          return archive.createFileReadStream(entry)
-        }
-      }, display, function (err) {
-        if (err) throw err
-      })
-    }
-    onclick(ev, entry)
-  }
-
-  return widget
+  return tree.widget
 }

--- a/index.js
+++ b/index.js
@@ -26,8 +26,6 @@ module.exports = function ui (archive, opts, onclick) {
 
   var stream = archive.list({live: true})
   stream.on('data', function (entry) {
-    if (archive.owner) help.innerHTML = 'drag and drop files'
-    else help.innerHTML = ''
     entry.createReadStream = function () {
       return archive.createFileReadStream(entry)
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "intro.js": "^2.1.0",
     "render-data": "^1.0.0",
     "speedometer": "^1.0.0",
-    "yo-fs": "^1.0.3",
+    "yo-fs": "^2.0.0",
     "yo-yo": "^1.2.1"
   },
   "gh-pages-deploy": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gh-pages-deploy": "^0.4.2",
     "http-server": "^0.9.0",
     "hyperdrive": "^6.2.1",
-    "hyperdrive-archive-swarm": "^3.0.0",
+    "hyperdrive-archive-swarm": "^3.0.1",
     "level-browserify": "^1.1.0",
     "memdb": "^1.3.1",
     "standard": "^7.1.2",


### PR DESCRIPTION
So I've been thinking about this a little, and yo-yo doesn't really have a concept of 1st class widgets (yet). So that means a widget function should only take state and return DOM, nothing else. If a widget starts performing asynchronous operations internally, there will need to be something to manage its lifetime, not always fully recreating it, etc.

This way we don't have those problems and it works...For now at least. In the future I can see problems arising where it _does_ make a lot more sense for a widget to manage its persistent internal state itself, because otherwise would be too complicated.

this fixes https://github.com/juliangruber/dat-desktop/issues/16

implemented in dat-desktop here: https://github.com/juliangruber/dat-desktop/commit/030c3fb06f8e86a56f736518e54b2acaef79bd0d

cc @maxogden @mafintosh 
